### PR TITLE
fix: imagemagick v7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ or clone the repo:
 Subclass `gm` to enable ImageMagick
 
 ```js
-var fs = require('fs')
-  , gm = require('gm').subClass({imageMagick: true});
+var fs = require('fs');
+// use Imagemagick pre-v7 CLI syntax (individual commands, incompatible with windows)
+var gm = require('gm').subClass({imageMagick: true});
+// OR use Imagemagick v7+ CLI syntax (`magick` command)
+var gm = require('gm').subClass({imageMagick: '7+'});
 
 // resize and remove EXIF profile data
 gm('/path/to/my/img.jpg')

--- a/lib/command.js
+++ b/lib/command.js
@@ -202,9 +202,10 @@ module.exports = function (proto) {
     */
 
   proto._spawn = function _spawn (args, bufferOutput, callback) {
+    var isImageMagick = this._options && this._options.imageMagick;
     var appPath = this._options.appPath || '';
-    var bin = this._options.imageMagick
-      ? appPath + args.shift()
+    var bin = isImageMagick
+      ? appPath + (isImageMagick === '7+' ? 'magick' : args.shift())
       : appPath + 'gm'
 
     var cmd = bin + ' ' + args.map(utils.escape).join(' ')

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -19,16 +19,14 @@ var spawn = require('cross-spawn');
 
 module.exports = exports = function (proto) {
   function compare(orig, compareTo, options, cb) {
+    var args = ['compare', '-metric', 'mse', orig, compareTo]
 
     var isImageMagick = this._options && this._options.imageMagick;
     var appPath = this._options && this._options.appPath || '';
     var bin = isImageMagick
-      ? appPath + 'compare' 
+      ? appPath + (isImageMagick === '7+' ? 'magick' : args.shift())
       : appPath + 'gm'
-    var args = ['-metric', 'mse', orig, compareTo]
-    if (!isImageMagick) {
-        args.unshift('compare');
-    }
+
     var tolerance = 0.4;
     // outputting the diff image
     if (typeof options === 'object') {


### PR DESCRIPTION
v7 syntax is opt-in with `require('gm').subClass({imageMagick: '7+'});`

initially addressed in https://github.com/ovos/gm/commit/4198750ffba43085ae5063d9b9944b140bf48a36 but since that made v7 required it broke CI installations where Imagemagick is still at version 6.x - e.g. ubuntu still has only imagemagick v6 in their apt repos :(

Make v6 syntax the default one with when `gm` is subclassed with `{imageMagick: true}` options with v7 to be opt-in with `{imageMagick: '7+'}`